### PR TITLE
CLI アプリ化

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ Please install Node.js (Upper v12.0.0)
 ```
 npm install
 npm run build
+chmod +x dist/index.js
+npm link
 export SLACK_TOKEN=xoxb-9999999999999-9999999999999-xxxxxxxxxxxxxxxxxxxxxx
-node dist/index.js {httpmethod} {apiname} --args1 hogehoge --args2 fugafuga
+slack-api-command {httpmethod} {apiname} --args1 hogehoge --args2 fugafuga
 ```
 
 # Example

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
       "pre-commit": "pretty-quick --staged"
     }
   },
+  "bin": {
+    "slack-api-command": "./dist/index.js"
+  },
   "author": "Soichiro Yoshimura (sifue)",
   "license": "MIT",
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#! /usr/bin/env node
 // Slack API methdos https://api.slack.com/methods
 
 import axios from 'axios';


### PR DESCRIPTION
このリポジトリのディレクトリに移動しなくても、 `slack-api-command` というふうに呼び出せるようにしました。