### PR TITLE
Auto Cursor モードのとき、sleep が 1000 msec でハードコードされている点を、環境変数 SLACK_COMMAND_AC_SLEEP を渡すように変更

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ const axiosInstance = axios.create({
       const sleep = (msec: number) =>
         new Promise((resolve) => setTimeout(resolve, msec));
       if (process.env.SLACK_COMMAND_AC_SLEEP) {
-        await sleep(1000);
+        await sleep(parseInt(process.env.SLACK_COMMAND_AC_SLEEP));
       }
 
       const currentRes = await (axiosInstance as any)[method](


### PR DESCRIPTION
pass the environment variable to sleep function

Auto Cursor モードのとき、sleep が 1000 msec でハードコードされている点を、環境変数 SLACK_COMMAND_AC_SLEEP を渡すように変更